### PR TITLE
RDjs ahora admite http patch usando json patch document

### DIFF
--- a/app/build/RDJs.js
+++ b/app/build/RDJs.js
@@ -1,10 +1,8 @@
 "use strict";
+exports.__esModule = true;
 if (exports === undefined) {
     var exports = {};
 }
-/**
- * Instance is an RDJs controller.
- */
 var RD = (function () {
     function RD() {
     }
@@ -60,6 +58,15 @@ var RD = (function () {
         if (async === void 0) { async = true; }
         var results = new Promise(function (resolve, reject) {
             _this.baseXhr("PUT", url, headers, resolve, reject)
+                .send(params === undefined ? undefined : params);
+        });
+        return results;
+    };
+    RD.prototype.patch = function (url, params, headers, async) {
+        var _this = this;
+        if (async === void 0) { async = true; }
+        var results = new Promise(function (resolve, reject) {
+            _this.baseXhr("PATCH", url, headers, resolve, reject)
                 .send(params === undefined ? undefined : params);
         });
         return results;

--- a/app/src/RDJs.ts
+++ b/app/src/RDJs.ts
@@ -4,6 +4,11 @@ if (exports === undefined) {
 /**
  * Instance is an RDJs controller.  
  */
+interface JsonPatchDocument {
+    op: string;
+    path: string;
+    value: any;
+}
 
  class RD { 
   private baseXhr(type: string, url: string, headers: { key: string; value: any; }[], resolve: Function, reject: Function, async: boolean = true): XMLHttpRequest {
@@ -64,6 +69,15 @@ if (exports === undefined) {
     });
     return results;
   }
+
+  public patch(url: string, params: JsonPatchDocument[], headers: { key: string; value: any; }[], async: boolean = true): Promise<any> {
+    let results = new Promise<any>((resolve, reject) => {
+      this.baseXhr("PATCH", url, headers, resolve, reject)
+        .send(params === undefined ? undefined : params);
+    });
+    return results;
+  }
+
   public delete(url: string, params: any, headers: { key: string; value: any; }[], async: boolean = true): Promise<any> {
     let results = new Promise<any>((resolve, reject) => {
       this.baseXhr("DELETE", url, headers, resolve, reject)


### PR DESCRIPTION
RDjs ahora admite http patch usando json patch document, para mayor información referente a json patch visitar http://jsonpatch.com/